### PR TITLE
LDAP client: auto create home dir when user connects for the first time

### DIFF
--- a/templates/hosts/debian/ldapclient/provision.sh
+++ b/templates/hosts/debian/ldapclient/provision.sh
@@ -36,4 +36,4 @@ echo "bind_timelimit 2" >> /etc/libnss-ldap.conf
 echo "bind_policy soft" >> /etc/libnss-ldap.conf
 
 # auto create home dir when an LDAP user connects for the first time
-echo "session required pam_mkhomedir.so skel=/etc/skel umask=0077" >> /etc/pam.d/common-session
+echo "session required pam_mkhomedir.so skel=/etc/skel umask=0022" >> /etc/pam.d/common-session

--- a/templates/hosts/debian/ldapclient/provision.sh
+++ b/templates/hosts/debian/ldapclient/provision.sh
@@ -34,3 +34,6 @@ echo "bind_timelimit 2" >> /etc/pam_ldap.conf
 echo "bind_policy soft" >> /etc/pam_ldap.conf
 echo "bind_timelimit 2" >> /etc/libnss-ldap.conf
 echo "bind_policy soft" >> /etc/libnss-ldap.conf
+
+# auto create home dir when an LDAP user connects for the first time
+echo "session required pam_mkhomedir.so skel=/etc/skel umask=0077" >> /etc/pam.d/common-session


### PR DESCRIPTION
Especially useful when "commercial" user connects to "intranet" for the first time during TP 1

I tested it by changing it in the running "intranet" machine, but I did not test the full automation.