### PR TITLE
Shorten listHosts() and remove trailing ", "

### DIFF
--- a/mi-lxc.py
+++ b/mi-lxc.py
@@ -406,10 +406,7 @@ def usage():
     print(listHosts())
 
 def listHosts():
-    str = ""
-    for host in hosts:
-            str += host.name + ', '
-    return str
+    return ", ".join(host.name for host in hosts)
 
 def terminal_size():
     import fcntl, termios, struct


### PR DESCRIPTION
This version is more pythonic, and it also fixes the trailing ", "

* before:
> Names are: [...] transit-a-router, transit-b-router,

* after:
> Names are: [...] transit-a-router, transit-b-router