### PR TITLE
Create home folders from /etc/skel instead of empty

### DIFF
--- a/groups/isp-a/hacker/provision.sh
+++ b/groups/isp-a/hacker/provision.sh
@@ -11,6 +11,7 @@ apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -y python3
 DEBIAN_FRONTEND=noninteractive apt-get install -y python3-requests
 
+cp -r /etc/skel /home/debian
 cp -ar homedir/* /home/debian/
 ln -sf /home/debian/background.jpg /usr/share/images/desktop-base/default
 

--- a/groups/target/admin/provision.sh
+++ b/groups/target/admin/provision.sh
@@ -12,6 +12,7 @@ cd `dirname $0`
 
 #cp -ar /mnt/lxc/commercial/homedir/* /home/debian/
 #ln -sf /home/debian/background.jpg /usr/share/images/desktop-base/default
+cp -r /etc/skel /home/admin
 mkdir -p /home/admin/.ssh
 
 chown -R 1003:1001 /home/admin

--- a/groups/target/commercial/provision.sh
+++ b/groups/target/commercial/provision.sh
@@ -12,7 +12,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pyasn1 python3-psutil 
 
 #cp -ar /mnt/lxc/commercial/homedir/* /home/debian/
 #ln -sf /home/debian/background.jpg /usr/share/images/desktop-base/default
-mkdir /home/commercial
+cp -r /etc/skel /home/commercial
 mkdir -p /home/commercial/.ssh
 
 chown -R 1001:1001 /home/commercial

--- a/groups/target/dev/provision.sh
+++ b/groups/target/dev/provision.sh
@@ -12,6 +12,7 @@ cd `dirname $0`
 
 #cp -ar /mnt/lxc/commercial/homedir/* /home/debian/
 #ln -sf /home/debian/background.jpg /usr/share/images/desktop-base/default
+cp -r /etc/skel /home/dev
 mkdir -p /home/dev/.ssh
 
 chown -R 1002:1001 /home/dev
@@ -45,4 +46,4 @@ qi5rJDmBWURpzyutQVoUt2Mkqx+DnMwGze4pZRthVJG1e2bUL/RmoA+t
 -----END RSA PRIVATE KEY-----" > /home/dev/.ssh/id_rsa
 chmod 600 /home/dev/.ssh/id_rsa
 
-# chown -R 1002:1001 /home/commercial
+chown -R 1002:1001 /home/dev

--- a/groups/target/filer/provision.sh
+++ b/groups/target/filer/provision.sh
@@ -5,14 +5,17 @@ if [ -z $MILXCGUARD ] ; then exit 1; fi
 DIR=`dirname $0`
 cd `dirname $0`
 
+cp -r /etc/skel /home/commercial
 mkdir -p /home/commercial/.ssh
 echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDmAxoKkJqasCB83L8/aD9D7583NK1HoIuJJv4Gq6r6HzaIkgcbaUWzivuyPXEiY6eaVAJHLr4IUMOfGr2y1ap5HlXNJ+Zk9jfwcXRDwWnnRJProkIfluotPjGA5DZrZMyK0ip/tPJjFFzUM+JiqSzTSL61BBd0TH3IBqLeuFipDNcQzNdrgB8IlvgxlaZ2b9q5OlJE9r83OCZh8977E3+FHPJTqj98ZfG8k1EYDCAPlvQslkfZJ4Q4kRpljc3E8fbtoX4bViNQiIHodYOieiiStwhmhqGj7X9J31CvvDODCM4R4ABG32tCFFyJslYLtLyGwUM1fmbMsmTDl3EYDw4D debian@lxc-infra-commercial" > /home/commercial/.ssh/authorized_keys
 chown -R 1001:1001 /home/commercial
 
+cp -r /etc/skel /home/dev
 mkdir -p /home/dev/.ssh
 echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDa4dl8EK4raMwsjuesjKrZlMRuSOAL2JuiOdidQ3ZnJsKi2csLD1ajuHixLJCpNkdqwgovdK6h/PJWCRMp/5LkJa+dq47xYkXNqQnAOTG+HbwlPxspJz7dPq7nb0hnAFDg1UhwqKAwG/1DPI3sLlXmL6M4+VclKCT69LC1mkCDChQUK7uuCZC3cdERxbgXTiUs4o9ITLlOlPXTRPyoE+hooFcFgiDO/S4OtSVBzyXZRQo1OZriiWhJugoGDOWJdDGjNfNb2lXD0ZGJ8yrQYk64DuMwWflA3g/ijEKgq9/6qUCbIruQI7zkoq64uMgz4VJzJMUyxe7vFoA917Ah5rVT root@lxc-infra-commercial" > /home/dev/.ssh/authorized_keys
 chown -R 1002:1001 /home/dev
 
+cp -r /etc/skel /home/admin
 mkdir -p /home/admin/.ssh
 echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDd4EcxDEqErntx9Xhira3OkRY4+wbZHtM03HW6KmhhjgpIZuPUclSriht6+/8htBxqNd6H41aZllY9c6ii6sHRsLj0n9//mWVyLQZhIatxynFEmnDceJjp+wuMt+uS5uLXfw5ox3TVYS3rwDgaLckWqRaiPy/ezkq9zk+zEHo0FemhtW7C61OKjFIAa6DhDoadZWq1T2NieeukZ7++CtV/fgXrjsMzl8jfV9T+d0GqB7/K3dDzOTBE5Oa9n+CjpCc13J2pxm3fh7BZSlHlbG5MgIPV0Ymabo7rqgb0Atm/fxEf4uZ1bNrEaC6ixP2b+5gOFYdOe6clcQNESqFlJ39 admin@lxc-infra-admin" > /home/admin/.ssh/authorized_keys
 chown -R 1003:1001 /home/admin

--- a/groups/target/intranet/provision.sh
+++ b/groups/target/intranet/provision.sh
@@ -25,6 +25,7 @@ cp compta.txt /var/www/html/
 chmod 666 /var/www/html/clients.txt
 chmod 666 /var/www/html/compta.txt
 
+cp -r /etc/skel /home/dev
 mkdir -p /home/dev/.ssh
 echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDa4dl8EK4raMwsjuesjKrZlMRuSOAL2JuiOdidQ3ZnJsKi2csLD1ajuHixLJCpNkdqwgovdK6h/PJWCRMp/5LkJa+dq47xYkXNqQnAOTG+HbwlPxspJz7dPq7nb0hnAFDg1UhwqKAwG/1DPI3sLlXmL6M4+VclKCT69LC1mkCDChQUK7uuCZC3cdERxbgXTiUs4o9ITLlOlPXTRPyoE+hooFcFgiDO/S4OtSVBzyXZRQo1OZriiWhJugoGDOWJdDGjNfNb2lXD0ZGJ8yrQYk64DuMwWflA3g/ijEKgq9/6qUCbIruQI7zkoq64uMgz4VJzJMUyxe7vFoA917Ah5rVT root@lxc-infra-commercial" > /home/dev/.ssh/authorized_keys
 chown -R 1002:1001 /home/dev # should be 1001 (employees)

--- a/templates/hosts/debian/mailclient/provision.sh
+++ b/templates/hosts/debian/mailclient/provision.sh
@@ -14,6 +14,7 @@ if [ -z $login ] ; then
   login="debian"
 fi
 
+[[ ! -d /home/$login ]] && cp -r /etc/skel /home/$login
 cp -ar claws-mail /home/$login/.claws-mail
 #chown -R $login /home/$login/.claws-mail
 chmod -R 777 /home/$login/.claws-mail

--- a/templates/hosts/debian/mailserver/provision.sh
+++ b/templates/hosts/debian/mailserver/provision.sh
@@ -29,6 +29,7 @@ fi
 
 # create mail directories for already created users
 for i in `ls /home`; do
+  cp -r /etc/skel /home/$i
   mkdir -p /home/$i/mail
   touch /home/$i/mail/Drafts /home/$i/mail/Queue /home/$i/mail/Sent /home/$i/mail/Trash
   echo -e "Trash\nDrafts\nQueue\nSent" >> /home/$i/mail/.subscriptions


### PR DESCRIPTION
The normal "skel" process doesn't apply if we already created the folder even for a single small file!
It allows to benefit from a95a751d1300b02b1a4988240d9ef039eabbc70f "Successfully attached to..."