### PR TITLE
Fix dev homedir permissions

### DIFF
--- a/groups/target/dev/provision.sh
+++ b/groups/target/dev/provision.sh
@@ -14,8 +14,6 @@ cd `dirname $0`
 #ln -sf /home/debian/background.jpg /usr/share/images/desktop-base/default
 mkdir -p /home/dev/.ssh
 
-chown -R 1002:1001 /home/dev
-
 echo -e "-----BEGIN RSA PRIVATE KEY-----
 MIIEpgIBAAKCAQEA2uHZfBCuK2jMLI7nrIyq2ZTEbkjgC9ibojnYnUN2ZybCotnL
 Cw9Wo7h4sSyQqTZHasIKL3SuofzyVgkTKf+S5CWvnauO8WJFzakJwDkxvh28JT8b

--- a/groups/target/dev/provision.sh
+++ b/groups/target/dev/provision.sh
@@ -45,4 +45,4 @@ qi5rJDmBWURpzyutQVoUt2Mkqx+DnMwGze4pZRthVJG1e2bUL/RmoA+t
 -----END RSA PRIVATE KEY-----" > /home/dev/.ssh/id_rsa
 chmod 600 /home/dev/.ssh/id_rsa
 
-# chown -R 1002:1001 /home/commercial
+chown -R 1002:1001 /home/dev


### PR DESCRIPTION
Before, sshfs failed because the private SSH key wasn't readable by dev!